### PR TITLE
feat: add PS_count_panel Photoshop extension script

### DIFF
--- a/scripts/PS_count_panel/PS notify panel.jsx
+++ b/scripts/PS_count_panel/PS notify panel.jsx
@@ -1,0 +1,18 @@
+#target photoshop
+// Sends the current open documents (count + active + names) to the
+// Open Files Counter panel over a local TCP socket. Works even during a
+// Batch, because the panel receives it in a separate process (not through
+// PS's blocked main thread). Payload format: COUNT|ACTIVE|name1|name2|...
+try {
+    var c = app.documents.length;
+    var a = c > 0 ? app.activeDocument.name : "";
+    var names = [];
+    for (var i = 0; i < c; i++) names.push(app.documents[i].name);
+    var payload = c + "|" + a + "|" + names.join("|");
+
+    var s = new Socket();
+    if (s.open("127.0.0.1:45678", "UTF-8")) {
+        s.write(payload);
+        s.close();
+    }
+} catch (e) {}

--- a/scripts/PS_count_panel/README.md
+++ b/scripts/PS_count_panel/README.md
@@ -1,0 +1,150 @@
+# Open Files Counter — Photoshop panel
+
+A small Photoshop CEP panel that shows the number of open documents and a
+clickable list of their names. It updates **live**, even while a Batch/action
+is closing files one by one.
+
+Tested on Adobe Photoshop 2026 (Windows). Should also work on 2021–2025.
+
+---
+
+## Contents
+
+```
+PS_count_panel/
+├── extension/               ← the CEP panel
+│   ├── index.html           ← panel UI + logic
+│   └── CSXS/
+│       └── manifest.xml     ← panel registration (Node.js enabled)
+├── PS notify panel.jsx      ← script that pushes updates during a Batch
+└── README.md
+```
+
+---
+
+## How it works
+
+- The **panel** (`extension/`) polls Photoshop every 500 ms via `evalScript`
+  and shows the count + file list. Clicking a name switches to that document.
+- During a **Batch/action**, Photoshop's main thread is saturated, so
+  `evalScript` (and CSXSEvents) are blocked until the batch finishes — the
+  panel would otherwise freeze on a stale count.
+- To update live during a batch, the **`PS notify panel.jsx`** script is added
+  as a step inside the action. When it runs it opens a **local TCP socket**
+  (`127.0.0.1:45678`) and sends `COUNT|ACTIVE|name1|name2|...`.
+- The panel runs in its **own process** (CEF + Node.js) and listens on that
+  port, so it receives the push even while Photoshop itself is busy. This is
+  why Node.js is enabled in the manifest (`--enable-nodejs --mixed-context`).
+
+The small `evt: N` badge in the panel's top-right corner counts how many socket
+pushes have been received — handy for confirming the action step is firing.
+
+---
+
+## Installation
+
+### 1. Install the panel (CEP extension)
+
+Copy the **`extension`** folder to Photoshop's user extensions folder and name
+it `com.openfiles.counter`:
+
+**Windows**
+```
+%APPDATA%\Adobe\CEP\extensions\com.openfiles.counter\
+```
+i.e. `C:\Users\<you>\AppData\Roaming\Adobe\CEP\extensions\com.openfiles.counter\`
+
+**macOS**
+```
+~/Library/Application Support/Adobe/CEP/extensions/com.openfiles.counter/
+```
+
+The final layout must be:
+```
+com.openfiles.counter/
+├── index.html
+└── CSXS/manifest.xml
+```
+
+### 2. Allow unsigned extensions
+
+This panel is unsigned, so enable debug mode once.
+
+**Windows** — run in PowerShell (covers the common CEP versions):
+```powershell
+'CSXS.11','CSXS.12','CSXS.13' | ForEach-Object {
+  New-Item -Path "HKCU:\SOFTWARE\Adobe\$_" -Force | Out-Null
+  Set-ItemProperty -Path "HKCU:\SOFTWARE\Adobe\$_" -Name PlayerDebugMode -Value 1 -Type String
+}
+```
+
+**macOS** — run in Terminal:
+```bash
+defaults write com.adobe.CSXS.11 PlayerDebugMode 1
+defaults write com.adobe.CSXS.12 PlayerDebugMode 1
+defaults write com.adobe.CSXS.13 PlayerDebugMode 1
+```
+
+### 3. Install the notify script
+
+Copy **`PS notify panel.jsx`** into Photoshop's Scripts folder (needs admin on
+Windows — click *Continue* when prompted):
+
+**Windows**
+```
+C:\Program Files\Adobe\Adobe Photoshop 2026\Presets\Scripts\
+```
+**macOS**
+```
+/Applications/Adobe Photoshop 2026/Presets/Scripts/
+```
+
+### 4. Restart Photoshop
+
+Open the panel from **Window ▸ Extensions (Legacy) ▸ Open Files Counter**.
+
+---
+
+## Usage
+
+### Everyday
+Just keep the panel open (dock it next to Layers). It shows the live count and
+list. Click any filename to jump to that document.
+
+### Live updates during a Batch
+To make the count/list update *while an action closes files*:
+
+1. **Window ▸ Actions**, open your action.
+2. Select the step **before** the final *Close* step.
+3. Press **Record**.
+4. Run **File ▸ Scripts ▸ PS notify panel** once.
+5. Press **Stop**. Drag the new step so it sits right after *Close* (so it
+   reports the count *after* each file is closed).
+6. Run **File ▸ Automate ▸ Batch** as usual — the panel now updates per file.
+
+Confirm it's working: the `evt:` badge in the panel increments on each file.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Panel not in the menu | Extension folder misnamed, or debug mode not set (step 2). Must be `com.openfiles.counter` with `index.html` + `CSXS/manifest.xml` inside. |
+| `evt: no node` / `no net` | Node.js not enabled — check `manifest.xml` has the `<CEFCommandLine>` block with `--enable-nodejs`. Restart PS. |
+| `evt: port busy` | Another process holds port 45678. Change the port in **both** `index.html` (`PORT`) and `PS notify panel.jsx` (the `127.0.0.1:PORT` string). |
+| Count updates during batch but list doesn't | You have an older `PS notify panel.jsx` that only sends the count. Use the version here (sends `COUNT|ACTIVE|names…`). |
+| Nothing updates during batch | The script step isn't in the action, or `File ▸ Scripts ▸ PS notify panel` doesn't appear — re-do step 3 and re-record. |
+
+---
+
+## Notes / limitations
+
+- Windows-focused. The socket push mechanism is cross-platform in principle,
+  but paths and debug-mode commands above differ per OS (see each step).
+- CEP is a legacy Adobe technology. A future rewrite as a **UXP** plugin would
+  allow the panel's own button to be recorded directly into an action (via
+  `recordAction()`), removing the need for the separate `.jsx` step. That is a
+  larger rewrite and not done here.
+- Filenames containing a `|` character would break the pipe-delimited payload
+  (extremely rare in practice).

--- a/scripts/PS_count_panel/extension/CSXS/manifest.xml
+++ b/scripts/PS_count_panel/extension/CSXS/manifest.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ExtensionManifest Version="7.0"
+    ExtensionBundleId="com.openfiles.counter"
+    ExtensionBundleVersion="1.0.0"
+    ExtensionBundleAuthor="User">
+  <ExtensionList>
+    <Extension Id="com.openfiles.counter.panel" Version="1.0.0"/>
+  </ExtensionList>
+  <ExecutionEnvironment>
+    <HostList>
+      <Host Name="PHXS" Version="[0.0,99.9]"/>
+      <Host Name="PHSP" Version="[0.0,99.9]"/>
+    </HostList>
+    <LocaleList>
+      <Locale Code="All"/>
+    </LocaleList>
+    <RequiredRuntimeList>
+      <RequiredRuntime Name="CSXS" Version="7.0"/>
+    </RequiredRuntimeList>
+  </ExecutionEnvironment>
+  <DispatchInfoList>
+    <Extension Id="com.openfiles.counter.panel">
+      <DispatchInfo>
+        <Resources>
+          <MainPath>./index.html</MainPath>
+          <CEFCommandLine>
+            <Parameter>--enable-nodejs</Parameter>
+            <Parameter>--mixed-context</Parameter>
+          </CEFCommandLine>
+        </Resources>
+        <Lifecycle>
+          <AutoVisible>true</AutoVisible>
+        </Lifecycle>
+        <UI>
+          <Type>Panel</Type>
+          <Menu>Open Files Counter</Menu>
+          <Geometry>
+            <Size>
+              <Height>300</Height>
+              <Width>260</Width>
+            </Size>
+            <MinSize>
+              <Height>120</Height>
+              <Width>160</Width>
+            </MinSize>
+          </Geometry>
+        </UI>
+      </DispatchInfo>
+    </Extension>
+  </DispatchInfoList>
+</ExtensionManifest>

--- a/scripts/PS_count_panel/extension/index.html
+++ b/scripts/PS_count_panel/extension/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: Arial, sans-serif;
+    background: #323232;
+    color: #b8b8b8;
+    font-size: 12px;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    padding: 8px;
+    gap: 6px;
+  }
+  #head { display: flex; align-items: baseline; justify-content: space-between; }
+  #count { font-size: 15px; font-weight: bold; color: #e8e8e8; }
+  #evt { font-size: 10px; color: #666; }
+  #list { flex: 1; overflow-y: auto; }
+  .doc-item {
+    padding: 5px 8px; cursor: pointer;
+    border-bottom: 1px solid #2a2a2a;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .doc-item:hover { background: #3d3d3d; }
+  .doc-item.active { background: #1473e6; color: #fff; }
+</style>
+</head>
+<body>
+
+<div id="head">
+  <div id="count">Open files: …</div>
+  <div id="evt">evt: 0</div>
+</div>
+<div id="list"></div>
+
+<script>
+  var lastRaw = null;
+  var polling = false;
+
+  function evalPS(script, cb) {
+    if (window.__adobe_cep__ && typeof window.__adobe_cep__.evalScript === 'function') {
+      window.__adobe_cep__.evalScript(script, cb);
+    } else {
+      cb('ERROR: no bridge');
+    }
+  }
+
+  var evalScript =
+    'var _r="";' +
+    'try{' +
+    '  var _c=app.documents.length;' +
+    '  var _a=_c>0?app.activeDocument.name:"";' +
+    '  var _names=[];' +
+    '  for(var _i=0;_i<_c;_i++) _names.push(app.documents[_i].name);' +
+    '  _r=_c+"|"+_a+"|"+_names.join("|");' +
+    '}catch(_e){_r="ERR:"+_e.message;}' +
+    '_r;';
+
+  // --- Live push channel: TCP loopback socket ---
+  // The script step inside the action connects to this port and sends the
+  // current document count. This runs in the panel's OWN process (Node/CEF),
+  // so it keeps receiving even while PS's main thread is blocked by a Batch —
+  // unlike CSXSEvent or evalScript, which are stuck behind PS's message pump.
+  var PORT = 45678;
+  var evtCount = 0;
+
+  // Socket payload is the same pipe format as evalScript: COUNT|ACTIVE|name1|name2|...
+  function pushCount(str) {
+    evtCount++;
+    document.getElementById('evt').textContent = 'evt: ' + evtCount;
+    var raw = String(str);
+    if (raw.indexOf('|') === -1) return;
+    if (raw === lastRaw) return;
+    lastRaw = raw;
+    var parts  = raw.split('|');
+    var count  = parseInt(parts[0], 10) || 0;
+    var active = parts[1] || '';
+    var docs   = count > 0 ? parts.slice(2, 2 + count) : [];
+    renderList(count, active, docs);
+  }
+
+  var net = (typeof require === 'function') ? require('net') : null;
+  if (net) {
+    try {
+      var server = net.createServer(function(sock) {
+        var buf = '';
+        sock.on('data', function(d) { buf += d.toString(); });
+        sock.on('end', function() { pushCount(buf); });
+        sock.on('error', function() {});
+      });
+      server.on('error', function(e) {
+        document.getElementById('evt').textContent = 'evt: port busy';
+      });
+      server.listen(PORT, '127.0.0.1');
+    } catch (e) {
+      document.getElementById('evt').textContent = 'evt: no net';
+    }
+  } else {
+    document.getElementById('evt').textContent = 'evt: no node';
+  }
+
+  function update() {
+    if (polling) return;
+    polling = true;
+    evalPS(evalScript, function(raw) {
+      polling = false;
+      if (!raw || raw.indexOf('ERR:') === 0 || raw === 'EvalScript error.') return;
+      if (raw === lastRaw) return;
+      lastRaw = raw;
+      var parts  = raw.split('|');
+      var count  = parseInt(parts[0], 10) || 0;
+      var active = parts[1] || '';
+      var docs   = count > 0 ? parts.slice(2, 2 + count) : [];
+      renderList(count, active, docs);
+    });
+  }
+
+  function renderList(count, active, docs) {
+    document.getElementById('count').textContent = 'Open files: ' + count;
+    var list = document.getElementById('list');
+    list.innerHTML = '';
+    docs.forEach(function(name, i) {
+      var el = document.createElement('div');
+      el.className = 'doc-item' + (name === active ? ' active' : '');
+      el.textContent = (i + 1) + '.  ' + name;
+      el.title = name;
+      el.onclick = (function(idx) {
+        return function() {
+          evalPS('app.activeDocument = app.documents[' + idx + '];',
+            function() { lastRaw = null; update(); });
+        };
+      })(i);
+      list.appendChild(el);
+    });
+  }
+
+  update();
+  setInterval(update, 500);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `scripts/PS_count_panel/`: Photoshop CEP extension panel
- Includes JSX script, HTML panel UI, CSXS manifest, and README

🤖 Generated with [Claude Code](https://claude.com/claude-code)